### PR TITLE
Add lazy load to moderation work samples

### DIFF
--- a/src/components/JournalismWorkSamples.astro
+++ b/src/components/JournalismWorkSamples.astro
@@ -17,26 +17,32 @@ type Props = {
 const { title, loadMoreText } = Astro.props;
 ---
 
-<div class="flex flex-col gap-8" id="journalism-posts-container">
-  <h3 class="text-xl font-bold">{title}</h3>
+<div id="journalism-posts-container">
+  <div class="flex flex-col gap-8">
+    <h3 class="text-xl font-bold">{title}</h3>
 
-  <div class="flex flex-col gap-4">
+    <div class="flex flex-col gap-4">
+      {
+        journalismWorkSamples
+          .slice(0, 3)
+          .map(({ fields }) => <JournalismWorkSampleItem {...fields} />)
+      }
+    </div>
+
     {
-      journalismWorkSamples
-        .slice(0, 3)
-        .map(({ fields }) => <JournalismWorkSampleItem {...fields} />)
+      journalismWorkSamples.length > 3 && (
+        <div class="text-end">
+          <Button
+            hx-get="/partials/journalism-work-samples"
+            hx-vals='{"pageSize": "6"}'
+            hx-trigger="click"
+            hx-target="#journalism-posts-container"
+            hx-swap="innerHTML"
+          >
+            {loadMoreText}
+          </Button>
+        </div>
+      )
     }
-  </div>
-
-  <div class="text-end">
-    <Button
-      hx-get="/partials/journalism-work-samples"
-      hx-vals='{"pageSize": "6"}'
-      hx-trigger="click"
-      hx-target="#journalism-posts-container"
-      hx-swap="innerHTML"
-    >
-      {loadMoreText}
-    </Button>
   </div>
 </div>

--- a/src/components/ModerationWorkSamples.astro
+++ b/src/components/ModerationWorkSamples.astro
@@ -16,7 +16,7 @@ type Props = {
 const { title, loadMoreText } = Astro.props;
 ---
 
-<div id="moderation-posts-container" hx-on::before-swap="destoryAccordions()">
+<div id="moderation-posts-container" {...{ 'hx-on::before-swap': 'destroyAccordions()' }}>
   <div class="flex flex-col gap-8">
     <h2 class="text-xl font-bold">{title}</h2>
 

--- a/src/components/ModerationWorkSamples.astro
+++ b/src/components/ModerationWorkSamples.astro
@@ -1,6 +1,7 @@
 ---
-import { documentToHtmlString } from "@contentful/rich-text-html-renderer";
 import { getAllModerationWorkSamples } from "@/lib/contentful/utils";
+import Button from "./Button.astro";
+import ModerationWorkSamplesItem from "./ModerationWorkSamplesItem.astro";
 
 const moderationWorkSamples = await Astro.callAction(
   getAllModerationWorkSamples,
@@ -9,58 +10,56 @@ const moderationWorkSamples = await Astro.callAction(
 
 type Props = {
   title: string;
+  loadMoreText: string;
 };
 
-const { title } = Astro.props;
+const { title, loadMoreText } = Astro.props;
 ---
 
-<div class="flex flex-col gap-8">
-  <h2 class="text-xl font-bold">{title}</h2>
+<div id="moderation-posts-container" hx-on::before-swap="destoryAccordions()">
+  <div class="flex flex-col gap-8">
+    <h2 class="text-xl font-bold">{title}</h2>
 
-  <div class="hs-accordion-group flex flex-col gap-4">
+    <div class="hs-accordion-group flex flex-col gap-4">
+      {
+        moderationWorkSamples.slice(0, 3).map(({ fields }) => (
+         <ModerationWorkSamplesItem {...fields} />
+        ))
+      }
+    </div>
+
     {
-      moderationWorkSamples.map((sample, index) => (
-        <div class="hs-accordion group">
-          <button
-            aria-controls={`moderation-work-sample-${index}__content`}
-            class="hs-accordion-toggle relative flex w-full cursor-pointer items-center justify-between gap-8 bg-neutral-100 p-6 text-left transition-colors duration-500 group-[.active]:bg-black group-[.active]:text-white hover:bg-black hover:text-white md:p-8"
+      moderationWorkSamples.length > 3 && (
+        <div class="text-end">
+          <Button
+            hx-get="/partials/moderation-work-samples"
+            hx-vals='{"pageSize": "6"}'
+            hx-trigger="click"
+            hx-target="#moderation-posts-container"
+            hx-swap="innerHTML"
           >
-            <span class="flex w-full flex-col justify-between gap-x-8 gap-y-4 md:flex-row">
-              <span
-                id={`moderation-work-sample-${index}__title`}
-                class="font-bold"
-              >
-                {sample.fields.title}
-              </span>
-              <span class="md:text-end">{sample.fields.client}</span>
-            </span>
-            <svg
-              aria-hidden="true"
-              class="min-h-6 min-w-6 transition-all duration-500 group-hover:fill-white group-[.active]:rotate-180 group-[.active]:fill-white"
-              xmlns="http://www.w3.org/2000/svg"
-              height="24px"
-              viewBox="0 -960 960 960"
-              width="24px"
-            >
-              <path d="M440-160v-487L216-423l-56-57 320-320 320 320-56 57-224-224v487h-80Z" />
-            </svg>
-          </button>
-          <div
-            id={`moderation-work-sample-${index}__content`}
-            class="hs-accordion-content hidden overflow-hidden transition-[height] duration-500"
-            aria-labelledby={`moderation-work-sample-${index}__title`}
-          >
-            <div
-              class="prose px-6 pt-6 not-group-last:pb-5 md:px-8 md:pt-8"
-              set:html={documentToHtmlString(sample.fields.content, {preserveWhitespace: true})}
-            />
-          </div>
+            {loadMoreText}
+          </Button>
         </div>
-      ))
+      )
     }
   </div>
 </div>
 
 <script>
   import "@preline/accordion";
+</script>
+
+<script is:inline>
+function destoryAccordions() {
+  const accordions = document.querySelectorAll(".hs-accordion");
+
+  accordions.forEach((el) => {
+    const {element} = HSAccordion.getInstance(el, true);
+
+    if (element) {
+        element.destroy();
+      }
+    });
+  }
 </script>

--- a/src/components/ModerationWorkSamples.astro
+++ b/src/components/ModerationWorkSamples.astro
@@ -22,8 +22,8 @@ const { title, loadMoreText } = Astro.props;
 
     <div class="hs-accordion-group flex flex-col gap-4">
       {
-        moderationWorkSamples.slice(0, 3).map(({ fields }) => (
-         <ModerationWorkSamplesItem {...fields} />
+        moderationWorkSamples.slice(0, 3).map(({ fields }, index) => (
+         <ModerationWorkSamplesItem {...fields} index={index} />
         ))
       }
     </div>
@@ -51,7 +51,7 @@ const { title, loadMoreText } = Astro.props;
 </script>
 
 <script is:inline>
-function destoryAccordions() {
+function destroyAccordions() {
   const accordions = document.querySelectorAll(".hs-accordion");
 
   accordions.forEach((el) => {

--- a/src/components/ModerationWorkSamplesItem.astro
+++ b/src/components/ModerationWorkSamplesItem.astro
@@ -1,28 +1,26 @@
 ---
 import { documentToHtmlString } from "@contentful/rich-text-html-renderer";
 import type { Document } from "@contentful/rich-text-types";
-import { slugify } from "../lib/common";
 
 type Props = {
   title: string;
   content: Document;
   client: string;
+  index: number;
 };
 
-const { title, content, client } = Astro.props;
-
-const id = slugify(title);
+const { title, content, client, index } = Astro.props;
 
 ---
 
 <div class="hs-accordion group">
   <button
-    aria-controls={`moderation-work-sample-${id}__content`}
+    aria-controls={`moderation-work-sample-${index}__content`}
     class="hs-accordion-toggle relative flex w-full cursor-pointer items-center justify-between gap-8 bg-neutral-100 p-6 text-left transition-colors duration-500 group-[.active]:bg-black group-[.active]:text-white hover:bg-black hover:text-white md:p-8"
   >
             <span class="flex w-full flex-col justify-between gap-x-8 gap-y-4 md:flex-row">
               <span
-                id={`moderation-work-sample-${id}__title`}
+                id={`moderation-work-sample-${index}__title`}
                 class="font-bold"
               >
                 {title}
@@ -41,9 +39,9 @@ const id = slugify(title);
     </svg>
   </button>
   <div
-    id={`moderation-work-sample-${id}__content`}
+    id={`moderation-work-sample-${index}__content`}
     class="hs-accordion-content hidden overflow-hidden transition-[height] duration-500"
-    aria-labelledby={`moderation-work-sample-${id}__title`}
+    aria-labelledby={`moderation-work-sample-${index}__title`}
   >
     <div
       class="prose px-6 pt-6 not-group-last:pb-5 md:px-8 md:pt-8"

--- a/src/components/ModerationWorkSamplesItem.astro
+++ b/src/components/ModerationWorkSamplesItem.astro
@@ -1,0 +1,53 @@
+---
+import { documentToHtmlString } from "@contentful/rich-text-html-renderer";
+import type { Document } from "@contentful/rich-text-types";
+import { slugify } from "../lib/common";
+
+type Props = {
+  title: string;
+  content: Document;
+  client: string;
+};
+
+const { title, content, client } = Astro.props;
+
+const id = slugify(title);
+
+---
+
+<div class="hs-accordion group">
+  <button
+    aria-controls={`moderation-work-sample-${id}__content`}
+    class="hs-accordion-toggle relative flex w-full cursor-pointer items-center justify-between gap-8 bg-neutral-100 p-6 text-left transition-colors duration-500 group-[.active]:bg-black group-[.active]:text-white hover:bg-black hover:text-white md:p-8"
+  >
+            <span class="flex w-full flex-col justify-between gap-x-8 gap-y-4 md:flex-row">
+              <span
+                id={`moderation-work-sample-${id}__title`}
+                class="font-bold"
+              >
+                {title}
+              </span>
+              <span class="md:text-end">{client}</span>
+            </span>
+    <svg
+      aria-hidden="true"
+      class="min-h-6 min-w-6 transition-all duration-500 group-hover:fill-white group-[.active]:rotate-180 group-[.active]:fill-white"
+      xmlns="http://www.w3.org/2000/svg"
+      height="24px"
+      viewBox="0 -960 960 960"
+      width="24px"
+    >
+      <path d="M440-160v-487L216-423l-56-57 320-320 320 320-56 57-224-224v487h-80Z" />
+    </svg>
+  </button>
+  <div
+    id={`moderation-work-sample-${id}__content`}
+    class="hs-accordion-content hidden overflow-hidden transition-[height] duration-500"
+    aria-labelledby={`moderation-work-sample-${id}__title`}
+  >
+    <div
+      class="prose px-6 pt-6 not-group-last:pb-5 md:px-8 md:pt-8"
+      set:html={documentToHtmlString(content, {preserveWhitespace: true})}
+    />
+  </div>
+</div>

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -1,9 +1,0 @@
-export const slugify = (str: string) => {
-  str = str.replace(/^\s+|\s+$/g, '');
-  str = str.toLowerCase();
-  str = str.replace(/[^a-z0-9 -]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-');
-
-  return str;
-}

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -1,0 +1,9 @@
+export const slugify = (str: string) => {
+  str = str.replace(/^\s+|\s+$/g, '');
+  str = str.toLowerCase();
+  str = str.replace(/[^a-z0-9 -]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+
+  return str;
+}

--- a/src/lib/contentful/types.ts
+++ b/src/lib/contentful/types.ts
@@ -26,6 +26,7 @@ export type HomePage = {
     moderationDescription: EntryFieldTypes.RichText;
     moderationImage: EntryFieldTypes.AssetLink;
     moderationWorkSamplesTitle: EntryFieldTypes.Text;
+    moderationWorkSamplesLoadMoreText: EntryFieldTypes.Text;
     moderationClientsTitle: EntryFieldTypes.Text;
     resumeTitle: EntryFieldTypes.Text;
   };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,6 +26,7 @@ const {
   moderationDescription,
   moderationImage,
   moderationWorkSamplesTitle,
+  moderationWorkSamplesLoadMoreText,
   moderationClientsTitle,
   resumeTitle,
 } = await getHomePageEntry();
@@ -102,7 +103,7 @@ const {
       )
     }
 
-    <ModerationWorkSamples title={moderationWorkSamplesTitle} />
+    <ModerationWorkSamples title={moderationWorkSamplesTitle} loadMoreText={moderationWorkSamplesLoadMoreText} />
 
     <PodcastSample />
 

--- a/src/pages/partials/moderation-work-samples.astro
+++ b/src/pages/partials/moderation-work-samples.astro
@@ -1,14 +1,14 @@
 ---
-import { getAllJournalismWorkSamples, getHomePageEntry } from "@/lib/contentful/utils";
+import { getAllModerationWorkSamples, getHomePageEntry } from "@/lib/contentful/utils";
 import Button from "@/components/Button.astro";
-import JournalismWorkSampleItem from "@/components/JournalismWorkSampleItem.astro";
+import ModerationWorkSamplesItem from "@/components/ModerationWorkSamplesItem.astro";
 
 export const prerender = false;
 export const partial = true;
 
 const {
-  journalismWorkSamplesTitle,
-  journalismWorkSamplesLoadMoreText,
+  moderationWorkSamplesTitle,
+  moderationWorkSamplesLoadMoreText,
 } = await getHomePageEntry();
 
 const requestUrl = new URL(Astro.request.url);
@@ -17,12 +17,12 @@ const pageSizeFromUrl = requestUrl.searchParams.get("pageSize");
 
 const pageSize = pageSizeFromUrl ? parseInt(pageSizeFromUrl, 10) : 3;
 
-const journalismWorkSamples = await Astro.callAction(
-  getAllJournalismWorkSamples,
+const moderationWorkSamples = await Astro.callAction(
+  getAllModerationWorkSamples,
   undefined,
 );
 
-const itemsToDisplay = journalismWorkSamples.slice(0, pageSize);
+const itemsToDisplay = moderationWorkSamples.slice(0, pageSize);
 
 const isMoreDataAvailable = itemsToDisplay.length >= pageSize;
 
@@ -30,12 +30,12 @@ const hxValues = `{"pageSize": "${pageSize * 2}"}`;
 ---
 
 <div class="flex flex-col gap-8">
-  <h2 class="text-xl font-bold">{journalismWorkSamplesTitle}</h2>
+  <h2 class="text-xl font-bold">{moderationWorkSamplesTitle}</h2>
 
-  <div class="flex flex-col gap-4">
+  <div class="hs-accordion-group flex flex-col gap-4">
     {
       itemsToDisplay.map(({ fields }) => (
-        <JournalismWorkSampleItem {...fields} />
+        <ModerationWorkSamplesItem {...fields} />
       ))
     }
   </div>
@@ -44,15 +44,21 @@ const hxValues = `{"pageSize": "${pageSize * 2}"}`;
     isMoreDataAvailable && (
       <div class="text-end">
         <Button
-          hx-get="/partials/journalism-work-samples"
+          hx-get="/partials/moderation-work-samples"
           hx-vals={hxValues}
           hx-trigger="click"
-          hx-target="#journalism-posts-container"
+          hx-target="#moderation-posts-container"
           hx-swap="innerHTML"
         >
-          {journalismWorkSamplesLoadMoreText}
+          {moderationWorkSamplesLoadMoreText}
         </Button>
       </div>
     )
   }
 </div>
+
+<script>
+  import HSAccordion from "@preline/accordion";
+
+  HSAccordion.autoInit();
+</script>

--- a/src/pages/partials/moderation-work-samples.astro
+++ b/src/pages/partials/moderation-work-samples.astro
@@ -34,8 +34,8 @@ const hxValues = `{"pageSize": "${pageSize * 2}"}`;
 
   <div class="hs-accordion-group flex flex-col gap-4">
     {
-      itemsToDisplay.map(({ fields }) => (
-        <ModerationWorkSamplesItem {...fields} />
+      itemsToDisplay.map(({ fields }, index) => (
+        <ModerationWorkSamplesItem {...fields} index={index} />
       ))
     }
   </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an accordion-style display for moderation work samples, showing the first three items with a "Load More" button for additional samples.
  - Added dynamic titles and button labels for both journalism and moderation work samples, sourced from content management.
  - Added a new partial component for moderation work samples with pagination support.

- **Improvements**
  - Consolidated and improved the layout of journalism work samples and their "Load More" button for a cleaner user experience.
  - Enhanced accessibility and interaction for moderation work samples with improved accordion UI and screen reader support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->