### PR TITLE
fix: enable pre rendering for all pages

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from "@/layouts/layout.astro";
 
-export const prerender = false;
+export const prerender = true;
 ---
 
 <Layout containerClass="md:my-36">

--- a/src/pages/500.astro
+++ b/src/pages/500.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from "@/layouts/layout.astro";
 
-export const prerender = false;
+export const prerender = true;
 ---
 
 <Layout containerClass="md:my-36">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ import ClientRow from "@/components/ClientRow.astro";
 import JournalismWorkSamples from "@/components/JournalismWorkSamples.astro";
 import ContentfulImage from "@/components/ContentfulImage.astro";
 
-export const prerender = false;
+export const prerender = true;
 
 const {
   seoTitle,

--- a/src/pages/legal/[slug].astro
+++ b/src/pages/legal/[slug].astro
@@ -4,7 +4,7 @@ import { documentToHtmlString } from "@contentful/rich-text-html-renderer";
 import type { LegalPage } from "@/lib/contentful/types";
 import { contentfulClient } from "@/lib/contentful/client";
 
-export const prerender = false;
+export const prerender = true;
 
 export async function getStaticPaths() {
   const entries = await contentfulClient.getEntries<LegalPage>({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the homepage, error pages (404 and 500), and legal pages to be statically prerendered at build time, resulting in faster initial page loads and more consistent delivery of these pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->